### PR TITLE
Restore translation widget with protected branding

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -198,7 +198,7 @@
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round">
         <path d="M18 4H6l7 8-7 8h12"/>
       </svg>
-      <span id="scrambleText">
+      <span id="scrambleText" class="notranslate">
         <span class="scramble-char">I</span>
         <span class="scramble-char">I</span>
         <span class="scramble-char">M</span>
@@ -221,23 +221,20 @@
       <div class="contact-card">
         <span class="contact-name" data-i18n="contact.cards.organizer.title">Chief Organizer: Edwin Chen</span>
         <span><span class="contact-label" data-i18n="contact.emailLabel">Email:</span> <span class="contact-item">edwin.chen@iimoc.org</span></span>
-        <span><span class="contact-label" data-i18n="contact.phoneLabel">Phone:</span> <span class="contact-item">[redacted]</span></span>
       </div>
       <div class="contact-card">
           <span class="contact-name" data-i18n="contact.cards.advisor.title">Advisor: Rob Kolstad</span>
           <span><span class="contact-label" data-i18n="contact.emailLabel">Email:</span> <span class="contact-item">rob.kolstad@gmail.com</span></span>
-          <span><span class="contact-label" data-i18n="contact.phoneLabel">Phone:</span> <span class="contact-item">[redacted]</span></span>
       </div>
       <div class="contact-card">
           <span class="contact-name" data-i18n="contact.cards.dev.title">Site Dev: sirbread</span>
           <span><span class="contact-label" data-i18n="contact.emailLabel">Email:</span> <span class="contact-item">sirbread.dev@outlook.com</span></span>
-          <span><span class="contact-label" data-i18n="contact.phoneLabel">Phone:</span> <span class="contact-item">[redacted]</span></span>
       </div>
     </div>
   </div>
 </main>
 <footer class="footer">
-  <p>&copy; <span id="year"></span> IIMOC. All rights reserved.</p>
+  <p>&copy; <span id="year"></span> <span class="notranslate">IIMOC</span>. All rights reserved.</p>
 </footer>
 <script>
   document.getElementById('year').textContent = new Date().getFullYear();

--- a/index.html
+++ b/index.html
@@ -299,7 +299,7 @@
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round">
         <path d="M18 4H6l7 8-7 8h12"/>
       </svg>
-      <span id="scrambleText">
+      <span id="scrambleText" class="notranslate">
         <span class="scramble-char">I</span>
         <span class="scramble-char">I</span>
         <span class="scramble-char">M</span>
@@ -319,14 +319,14 @@
 
 <main>
   <div class="container">
-    <h1>IIMOC</h1>
+    <h1><span class="notranslate">IIMOC</span></h1>
     <span class="iimoc-full" data-i18n="hero.subtitle">International Math Optimization Challenge</span>
     <div class="sub" data-i18n="hero.tagline">One tough problem. One shot per club.</div>
 
     <div class="section">
       <div class="how-it-works-title" data-i18n="howItWorks.title">How It Works</div>
       <div class="about-section" data-i18n="howItWorks.description">
-        IIMOC is a global competition for high school STEM clubs. Each team gets an approachable but unsolvable optimization problem and four weeks to submit their best solution. The club with the lowest loss wins. Special awards for creativity and best approach are also given.
+        <span class="notranslate">IIMOC</span> is a global competition for high school STEM clubs. Each team gets an approachable but unsolvable optimization problem and four weeks to submit their best solution. The club with the lowest loss wins. Special awards for creativity and best approach are also given.
       </div>
       <div class="features">
         <div class="card">
@@ -430,7 +430,7 @@
 </main>
 
 <footer class="footer">
-  <p>&copy; <span id="year"></span> IIMOC. All rights reserved.</p>
+  <p>&copy; <span id="year"></span> <span class="notranslate">IIMOC</span>. All rights reserved.</p>
 </footer>
 <script>
   document.getElementById('year').textContent = new Date().getFullYear();


### PR DESCRIPTION
## Summary
- restore Google Translate styles, markup, and script so the site translates again while leaving the IIMOC name marked as non-translatable
- keep phone number lines removed from every contact card

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ccd0abe79883289b5a55eee81c42e0