### PR TITLE
Add 2025 competition timeline to homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -229,6 +229,29 @@
     font-family: inherit;
     letter-spacing: 1px;
   }
+  .timeline {
+    margin-top: 24px;
+    display: grid;
+    gap: 14px;
+  }
+  .timeline-item {
+    background: #19191c;
+    border: 1px solid #333;
+    border-radius: 6px;
+    padding: 16px 20px 14px 20px;
+  }
+  .timeline-date {
+    font-size: 1.05rem;
+    font-weight: bold;
+    color: #f0e7ff;
+    letter-spacing: 1.1px;
+  }
+  .timeline-label {
+    margin-top: 6px;
+    color: #cfcfcf;
+    font-size: 0.98rem;
+    letter-spacing: 0.6px;
+  }
   .icon { height: 22px; width: 22px; color: #b89bfa; stroke-width: 2.2; }
   .icon-yellow { color: #facc15; }
   .icon-green { color: #7ee787; }
@@ -340,10 +363,10 @@
           </div>
           <p>See how you stack up against clubs worldwide.</p>
         </div>
-      </div>
     </div>
+  </div>
 
-    <div class="section">
+  <div class="section">
       <h2 style="text-align:center;">Where Clubs Compete</h2>
       <div class="muted" style="text-align:center;">
         Join students from:
@@ -360,11 +383,35 @@
         </div>
       </div>
     </div>
+  </div>
 
-    <div class="section" style="margin-top:48px">
-      <h2 style="text-align:center;">Ready?</h2>
-      <div class="muted" style="text-align:center;">
+  <div class="section" style="margin-top:48px">
+    <h2 style="text-align:center;">2025 Competition Timeline</h2>
+    <div class="muted" style="text-align:center;">Mark your calendar for every stage of IIMOC 2025.</div>
+    <div class="timeline">
+      <div class="timeline-item">
+        <div class="timeline-date">Nov 10, 2025</div>
+        <div class="timeline-label">Application deadline</div>
       </div>
+      <div class="timeline-item">
+        <div class="timeline-date">Nov 22, 2025</div>
+        <div class="timeline-label">Competition begins</div>
+      </div>
+      <div class="timeline-item">
+        <div class="timeline-date">Dec 21, 2025</div>
+        <div class="timeline-label">Submission deadline</div>
+      </div>
+      <div class="timeline-item">
+        <div class="timeline-date">Dec 30, 2025</div>
+        <div class="timeline-label">Results released</div>
+      </div>
+    </div>
+  </div>
+
+  <div class="section" style="margin-top:48px">
+    <h2 style="text-align:center;">Ready?</h2>
+    <div class="muted" style="text-align:center;">
+    </div>
       <div class="cta-wrap" style="margin-top:19px;">
         <a class="btn-lg" href="https://docs.google.com/forms/d/1dH9oRff1Keqln8tVHDsGspRrDxFG_V3B-k6BU7P63_4/edit?usp=forms_home&ouid=116326193225924467042&ths=true" target="_blank" rel="noopener noreferrer">
           Sign Up


### PR DESCRIPTION
## Summary
- add a 2025 competition timeline section on the homepage
- style the timeline cards to match the existing dark theme

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d753d835c08328ae56a95045c3f3bd