### PR TITLE
Add cascadeX CXL sponsor entry

### DIFF
--- a/sponsor.html
+++ b/sponsor.html
@@ -208,8 +208,14 @@
     </div>
     <div class="sponsor-grid">
       <a class="sponsor-card" href="https://apmemory.com" target="_blank" rel="noopener noreferrer">
-        <div class="logo-slot"><img src="https://www.nxp.com/docs/connect/images/logos/AP%20Memory%20Logo%20-1.svg?imwidth=300"></div>
+        <div class="logo-slot"><img src="https://www.nxp.com/docs/connect/images/logos/AP%20Memory%20Logo%20-1.svg?imwidth=300" alt="AP Memory logo"></div>
       </a>
+      <div class="sponsor-card">
+        <div class="logo-slot">
+          <img src="https://www.computeexpresslink.org/hubfs/CXL%20Logo%20Horiz%20RGB.svg" alt="cascadeX CXL logo" style="max-width: 100%; max-height: 100%; object-fit: contain;" />
+        </div>
+        <div class="sponsor-name">cascadeX</div>
+      </div>
 
     </div>
   </div>


### PR DESCRIPTION
## Summary
- add cascadeX to the sponsor grid with the CXL logo
- add descriptive alt text for the existing AP Memory logo

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7670b05508328b9151e3826efad44